### PR TITLE
fixed a typo for Flutter_Go 代码开发规范.md

### DIFF
--- a/Flutter_Go 代码开发规范.md
+++ b/Flutter_Go 代码开发规范.md
@@ -279,7 +279,7 @@ void delete(String path) {
 
 ### 库的引用
 
-flutter go 中，导入lib下文件库，统一指定报名，避免过多的```../../```
+flutter go 中，导入lib下文件库，统一指定包名，避免过多的```../../```
 ```
 package:flutter_go/
 ```


### PR DESCRIPTION
fixed a typo [Flutter_Go 代码开发规范.md#L282](https://github.com/alibaba/flutter-go/blame/master/Flutter_Go%20%E4%BB%A3%E7%A0%81%E5%BC%80%E5%8F%91%E8%A7%84%E8%8C%83.md#L282) .