### PR TITLE
修复#357 #348 以及widget搜索的bug

### DIFF
--- a/lib/components/search_input.dart
+++ b/lib/components/search_input.dart
@@ -15,13 +15,9 @@ typedef void OnSubmit(String value);
 
 ///搜索结果内容显示面板
 class MaterialSearchResult<T> extends StatelessWidget {
-  const MaterialSearchResult({
-    Key key,
-    this.value,
-    this.text,
-    this.icon,
-    this.onTap
-  }) : super(key: key);
+  const MaterialSearchResult(
+      {Key key, this.value, this.text, this.icon, this.onTap})
+      : super(key: key);
 
   final String value;
   final VoidCallback onTap;
@@ -30,7 +26,6 @@ class MaterialSearchResult<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
     return new InkWell(
       onTap: this.onTap,
       child: new Container(
@@ -38,8 +33,14 @@ class MaterialSearchResult<T> extends StatelessWidget {
         padding: EdgeInsets.fromLTRB(20.0, 0.0, 20.0, 10.0),
         child: new Row(
           children: <Widget>[
-            new Container(width: 30.0, margin: EdgeInsets.only(right: 10), child: new Icon(icon)) ?? null,
-            new Expanded(child: new Text(value, style: Theme.of(context).textTheme.subhead)),
+            new Container(
+                    width: 30.0,
+                    margin: EdgeInsets.only(right: 10),
+                    child: new Icon(icon)) ??
+                null,
+            new Expanded(
+                child: new Text(value,
+                    style: Theme.of(context).textTheme.subhead)),
             new Text(text, style: Theme.of(context).textTheme.subhead)
           ],
         ),
@@ -124,6 +125,7 @@ class _MaterialSearchState<T> extends State<MaterialSearch> {
   }
 
   Timer _resultsTimer;
+
   Future _getResultsDebounced() async {
     if (_results.length == 0) {
       setState(() {
@@ -164,6 +166,7 @@ class _MaterialSearchState<T> extends State<MaterialSearch> {
     super.dispose();
     _resultsTimer?.cancel();
   }
+
   Widget buildBody(List results) {
     if (_criteria.isEmpty) {
       return History();
@@ -171,16 +174,11 @@ class _MaterialSearchState<T> extends State<MaterialSearch> {
       return new Center(
           child: new Padding(
               padding: const EdgeInsets.only(top: 50.0),
-              child: new CircularProgressIndicator()
-          )
-      );
+              child: new CircularProgressIndicator()));
     }
     if (results.isNotEmpty) {
-      var content = new SingleChildScrollView(
-          child: new Column(
-            children: results
-          )
-      );
+      var content =
+          new SingleChildScrollView(child: new Column(children: results));
       return content;
     }
     return Center(child: Text("暂无数据"));
@@ -241,7 +239,7 @@ class _MaterialSearchState<T> extends State<MaterialSearch> {
               ],
       ),
       body: buildBody(results),
-      );
+    );
   }
 }
 
@@ -405,34 +403,35 @@ class SearchInput extends StatelessWidget {
 }
 // wigdet干掉.=> componets
 
-
 class History extends StatefulWidget {
   const History() : super();
 
   @override
-  _History  createState() => _History();
+  _History createState() => _History();
 }
 
 // AppBar 默认的实例,有状态
 class _History extends State<History> {
   SearchHistoryList searchHistoryList = new SearchHistoryList();
+  bool refreshFlag;
 
   @override
   void initState() {
     super.initState();
+    this.refreshFlag = true;
   }
 
   @override
   void dispose() {
     super.dispose();
   }
+
   buildChips(BuildContext context) {
     List<Widget> list = [];
     List<SearchHistory> historyList = searchHistoryList.getList();
     print("historyList> $historyList");
     Color bgColor = Theme.of(context).primaryColor;
     historyList.forEach((SearchHistory value) {
-
       Widget icon = CircleAvatar(
         backgroundColor: bgColor,
         child: Text(
@@ -445,20 +444,28 @@ class _History extends State<History> {
       }
       String targetRouter = value.targetRouter;
 
-      list.add(
-        InkWell(
-          onTap: () {
-            Application.router.navigateTo(context, "${targetRouter.toLowerCase()}", transition: TransitionType.inFromRight);
-          },
-          child: Chip(
-            avatar: icon,
-            label: Text("${value.name}"),
-          ),
-        )
-      );
+      list.add(InkWell(
+        onTap: () {
+          Application.router.navigateTo(
+              context, "${targetRouter.toLowerCase()}",
+              transition: TransitionType.inFromRight);
+        },
+        child: Chip(
+          avatar: icon,
+          label: Text("${value.name}"),
+        ),
+      ));
     });
     return list;
   }
+
+  _clearHistory() {
+    searchHistoryList.clear();
+    this.setState(() {
+      this.refreshFlag = !this.refreshFlag;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     List<Widget> childList = buildChips(context);
@@ -470,23 +477,36 @@ class _History extends State<History> {
     return Column(
       children: <Widget>[
         Container(
-          alignment: Alignment.centerLeft,
-          padding: EdgeInsets.fromLTRB(12.0, 12, 12, 0),
-          child: InkWell(
-            onLongPress: () {
-              searchHistoryList.clear();
-            },
-            child: Text('历史搜索'),
-          ),
-        ),
+            alignment: Alignment.centerLeft,
+            padding: EdgeInsets.fromLTRB(12.0, 12, 12, 0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                InkWell(
+                  onLongPress: () {
+                    searchHistoryList.clear();
+                  },
+                  child: Text('历史搜索'),
+                ),
+                GestureDetector(
+                  onTap: _clearHistory,
+                  child: Container(
+                    child: new Icon(Icons.delete,
+                        size: 24.0, color: Theme.of(context).accentColor),
+                    width: 30,
+                    height: 30,
+                  ),
+                )
+              ],
+            )),
         Container(
           padding: EdgeInsets.only(left: 10),
           alignment: Alignment.topLeft,
           child: Wrap(
-            spacing: 6.0, // gap between adjacent chips
-            runSpacing: 0.0, // gap between lines
-            children: childList
-          ),
+              spacing: 6.0, // gap between adjacent chips
+              runSpacing: 0.0, // gap between lines
+              children: childList),
         )
       ],
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -203,6 +203,7 @@ void _startupJpush() async {
 }
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   final provider = new Provider();
   await provider.init(true);
   sp = await SpUtil.getInstance();

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -24,6 +24,8 @@ import 'package:flutter_go/components/search_input.dart';
 import 'package:flutter_go/model/search_history.dart';
 import 'package:flutter_go/resources/widget_name_to_icon.dart';
 import 'package:flutter_go/model/user_info.dart';
+// 临时修复引入
+import '../widgets/elements/Form/Input/TextField/index.dart' as TextField;
 
 class AppPage extends StatefulWidget {
   final UserInformation userInfo;
@@ -96,10 +98,14 @@ class _MyHomePageState extends State<AppPage>
 
   void onWidgetTap(WidgetPoint widgetPoint, BuildContext context) {
     String targetName = widgetPoint.name;
-    searchHistoryList.add(
-        SearchHistory(name: targetName, targetRouter: widgetPoint.routerName));
-    print("searchHistoryList1 ${searchHistoryList.toString()}");
     String targetRouter = widgetPoint.routerName;
+    // 临时修复TextField路径问题
+    if(widgetPoint.name == 'TextField'){
+       targetRouter = TextField.Demo.routeName;
+    }
+    searchHistoryList.add(
+        SearchHistory(name: targetName, targetRouter: targetRouter));
+    print("searchHistoryList1 ${searchHistoryList.toString()}");
     Application.router.navigateTo(context, targetRouter.toLowerCase(),
         transition: TransitionType.inFromRight);
   }

--- a/lib/views/login_page/login_page.dart
+++ b/lib/views/login_page/login_page.dart
@@ -137,7 +137,7 @@ class _LoginPageState extends State<LoginPage> {
                     if (value.isEmpty) {
                       return "登录名不可为空!";
                     }
-                    return ' ';
+                    return null;
                   },
                   onSaved: (value) {
                     setState(() {
@@ -180,7 +180,7 @@ class _LoginPageState extends State<LoginPage> {
                     if (value == null || value.isEmpty) {
                       return "密码不可为空!";
                     }
-                    return '';
+                    return null;
                   },
                   onSaved: (value) {
                     setState(() {


### PR DESCRIPTION
#### What does this PR do?
1、解决某些高版本flutter卡在启动页的问题
Flutter (Channel master, v1.9.8-pre.79, on Mac OS X 10.14.6 18G95, locale
    en-CN)
2、解决登录页由于validator返回值不为null导致无法登录的问题
3、解决widget搜索,TextField服务端返回的routerName与本地不符导致的无法跳转的问题(临时解决)
4、添加widget搜索历史记录清除按钮

修改了
home.dart 102  main.dart 206  login_page 183 140   search_input.dart

关于启动页卡住的问题没有测低版本的兼容问题

#### New ENV variables
