### PR TITLE
feat: iOS 相关改进

### DIFF
--- a/lib/views/fourth_page/pages.dart
+++ b/lib/views/fourth_page/pages.dart
@@ -71,6 +71,7 @@ class Page extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final paddingTop = MediaQuery.of(context).padding.top;
     return Stack(
         //alignment: const Alignment(1.2, 0.6),
         children: [
@@ -90,7 +91,7 @@ class Page extends StatelessWidget {
           ),
           Positioned(
               right: -5.0,
-              top: 2.0,
+              top: paddingTop + 2.0,
               child: creatButton(context, 'GitHub', Icons.arrow_forward, 'goGithub')
           ),
         ]

--- a/lib/views/web_page/web_view_page.dart
+++ b/lib/views/web_page/web_view_page.dart
@@ -76,6 +76,7 @@ class _WebViewPageState extends State<WebViewPage> {
         withZoom: false,
         withLocalStorage: true,
         withJavascript: true,
+        hidden: true,
       ),
     );
   }


### PR DESCRIPTION
## 本 PR 做了什么？
* webview 增加 loading 的功能，同时解决 present (fromBottom) 视图，动画不正常的问题
  * webview 没有loading，表现不友好，所以直接使用了 hidden 属性，同时也把动画不正常的问题解决了。
* 修复 ‘关于手册页面’，GitHub 按钮遮挡状态栏的问题
  * SafeArea 就是 MediaQuery 减去 padding 的大小，所以，该地方直接使用 padding 

## 截图
### before

<img src="https://user-images.githubusercontent.com/6263633/68409635-66e83a80-01c2-11ea-8e94-d1dd54f68f21.png" width="30%" align=left />
<img src="https://user-images.githubusercontent.com/6263633/68409762-a1ea6e00-01c2-11ea-90e7-e90e6c416a0f.png" width="30%" align=center />

### after
<div>
<img src="https://user-images.githubusercontent.com/6263633/68409321-d578c880-01c1-11ea-937b-3d2b121b5e0a.png" width="30%" align=center />
<img src="https://user-images.githubusercontent.com/6263633/68409903-dfe79200-01c2-11ea-8207-84cc10625930.png" width="30%" align=center />
<img src="https://user-images.githubusercontent.com/6263633/68409798-b0388a00-01c2-11ea-812e-e84e02c18df9.png" width="30%" align=center />
</div>


