### PR TITLE
feat: 统一跳转行为

### DIFF
--- a/lib/components/category.dart
+++ b/lib/components/category.dart
@@ -43,15 +43,6 @@ class _CategoryHome extends State<CategoryHome> {
     searchCatOrWidget();
   }
 
-  Future<bool> back() {
-//    if (catHistory.length == 1) {
-//      return Future<bool>.value(true);
-//    }
-//    catHistory.removeLast();
-//    searchCatOrWidget();
-    return Future<bool>.value(true);
-  }
-
   void go(CommonItem cat) {
     catHistory.add(cat);
     searchCatOrWidget();
@@ -93,17 +84,10 @@ class _CategoryHome extends State<CategoryHome> {
       appBar: AppBar(
         title: Text("$title"),
       ),
-      body: WillPopScope(
-        onWillPop: () {
-          return back();
-        },
-
-        child: ListView(
-          children: <Widget>[
-            _buildContent(),
-          ],
-        ),
-        // child: Container(color: Colors.blue,child: Text('123'),),
+      body: ListView(
+        children: <Widget>[
+          _buildContent(),
+        ],
       ),
     );
   }

--- a/lib/components/list_view_item.dart
+++ b/lib/components/list_view_item.dart
@@ -1,3 +1,5 @@
+import 'package:fluro/fluro.dart';
+
 /// @Author: 一凨
 /// @Date: 2019-01-14 17:53:54
 /// @Last Modified by: 一凨
@@ -25,8 +27,11 @@ class ListViewItem extends StatelessWidget {
       child: ListTile(
         onTap: () {
           // _launchURL(itemUrl, context);
-          Application.router.navigateTo(context,
-              '${Routes.webViewPage}?title=${Uri.encodeComponent(itemTitle)}&url=${Uri.encodeComponent(itemUrl)}');
+          Application.router.navigateTo(
+            context,
+            '${Routes.webViewPage}?title=${Uri.encodeComponent(itemTitle)}&url=${Uri.encodeComponent(itemUrl)}',
+            transition: TransitionType.nativeModal,
+          );
         },
         title: Padding(
           child: Text(

--- a/lib/components/search_input.dart
+++ b/lib/components/search_input.dart
@@ -448,7 +448,7 @@ class _History extends State<History> {
         onTap: () {
           Application.router.navigateTo(
               context, "${targetRouter.toLowerCase()}",
-              transition: TransitionType.inFromRight);
+              transition: TransitionType.native);
         },
         child: Chip(
           avatar: icon,

--- a/lib/components/widget_demo.dart
+++ b/lib/components/widget_demo.dart
@@ -3,6 +3,7 @@
 
 import 'dart:core';
 
+import 'package:fluro/fluro.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_go/utils/data_utils.dart';
 
@@ -136,11 +137,17 @@ class _WidgetDemoState extends State<WidgetDemo> {
   void _selectValue(value) {
     if (value == 'doc') {
       // _launchURL(widget.docUrl);
-      Application.router.navigateTo(context,
-          '${Routes.webViewPage}?title=${Uri.encodeComponent(widget.title)} Doc&&url=${Uri.encodeComponent(widget.docUrl)}');
+      Application.router.navigateTo(
+        context,
+        '${Routes.webViewPage}?title=${Uri.encodeComponent(widget.title)} Doc&&url=${Uri.encodeComponent(widget.docUrl)}',
+        transition: TransitionType.nativeModal,
+      );
     } else if (value == 'code') {
-      Application.router.navigateTo(context,
-          '${Routes.codeView}?filePath=${Uri.encodeComponent(widget.codeUrl)}');
+      Application.router.navigateTo(
+        context,
+        '${Routes.codeView}?filePath=${Uri.encodeComponent(widget.codeUrl)}',
+        transition: TransitionType.nativeModal,
+      );
     }
   }
 

--- a/lib/components/widget_item_container.dart
+++ b/lib/components/widget_item_container.dart
@@ -23,7 +23,7 @@ class WidgetItemContainer extends StatelessWidget {
   /// 跳转goup
   void tapToGroup(CategoryComponent cate, BuildContext context) {
     Application.router.navigateTo(context, "/category/${cate.token}",
-        transition: TransitionType.inFromRight);
+        transition: TransitionType.native);
   }
 
   /// 跳转到老的widget界面
@@ -37,14 +37,14 @@ class WidgetItemContainer extends StatelessWidget {
       }
     });
     Application.router.navigateTo(context, targetRouter,
-        transition: TransitionType.inFromRight);
+        transition: TransitionType.native);
   }
 
   /// 跳转到新的标准页
   void tapToStandardPage(WidgetLeaf leaf, BuildContext context) {
     String targetRouter = '/standard-page/${leaf.pageId}';
     Application.router.navigateTo(context, targetRouter,
-        transition: TransitionType.inFromRight);
+        transition: TransitionType.native);
   }
 
   List<Widget> _buildColumns(context) {
@@ -81,7 +81,7 @@ class WidgetItemContainer extends StatelessWidget {
 
                     Application.router.navigateTo(
                         context, "/category/error/404",
-                        transition: TransitionType.inFromRight);
+                        transition: TransitionType.native);
                   },
                   index: addI,
                   totalCount: length,

--- a/lib/components/widget_item_container.dart
+++ b/lib/components/widget_item_container.dart
@@ -36,15 +36,21 @@ class WidgetItemContainer extends StatelessWidget {
         targetRouter = targetRouter.toLowerCase();
       }
     });
-    Application.router.navigateTo(context, targetRouter,
-        transition: TransitionType.native);
+    Application.router.navigateTo(
+      context,
+      targetRouter,
+      transition: TransitionType.native,
+    );
   }
 
   /// 跳转到新的标准页
   void tapToStandardPage(WidgetLeaf leaf, BuildContext context) {
     String targetRouter = '/standard-page/${leaf.pageId}';
-    Application.router.navigateTo(context, targetRouter,
-        transition: TransitionType.native);
+    Application.router.navigateTo(
+      context,
+      targetRouter,
+      transition: TransitionType.native,
+    );
   }
 
   List<Widget> _buildColumns(context) {

--- a/lib/views/collection_page/collection_full_page.dart
+++ b/lib/views/collection_page/collection_full_page.dart
@@ -115,7 +115,7 @@ class _CollectionFullPageState extends State<CollectionFullPage> {
             Icon(Icons.keyboard_arrow_right, color: Colors.grey, size: 30.0),
         onTap: () {
           Application.router.navigateTo(context, targetRouter.toLowerCase(),
-              transition: TransitionType.inFromRight);
+              transition: TransitionType.native);
         },
       ),
     );

--- a/lib/views/collection_page/collection_page.dart
+++ b/lib/views/collection_page/collection_page.dart
@@ -1,3 +1,5 @@
+import 'package:fluro/fluro.dart';
+
 /// @Author: 一凨
 /// @Date: 2019-01-08 17:12:58
 /// @Last Modified by: 一凨
@@ -118,11 +120,17 @@ class _CollectionPageState extends State<CollectionPage> {
         onTap: () {
           if (_collectionList[index - 1].router.contains('http')) {
             // 注意这里title已经转义过了
-            Application.router.navigateTo(context,
-                '${Routes.webViewPage}?title=${_collectionList[index - 1].name}&url=${Uri.encodeComponent(_collectionList[index - 1].router)}');
+            Application.router.navigateTo(
+              context,
+              '${Routes.webViewPage}?title=${_collectionList[index - 1].name}&url=${Uri.encodeComponent(_collectionList[index - 1].router)}',
+              transition: TransitionType.nativeModal,
+            );
           } else {
-            Application.router
-                .navigateTo(context, "${_collectionList[index - 1].router}");
+            Application.router.navigateTo(
+              context,
+              "${_collectionList[index - 1].router}",
+              transition: TransitionType.nativeModal,
+            );
           }
         },
       ),

--- a/lib/views/first_page/drawer_page.dart
+++ b/lib/views/first_page/drawer_page.dart
@@ -172,9 +172,11 @@ class _DrawerPageState extends State<DrawerPage> {
             style: textStyle,
           ),
           onTap: () {
-            Application.router.navigateTo(context,
-                '${Routes.collectionFullPage}?hasLogin=${hasLogin.toString()}',
-                transition: TransitionType.fadeIn);
+            Application.router.navigateTo(
+              context,
+              '${Routes.collectionFullPage}?hasLogin=${hasLogin.toString()}',
+              transition: TransitionType.nativeModal,
+            );
           },
         ),
         // new Divider(),
@@ -205,10 +207,18 @@ class _DrawerPageState extends State<DrawerPage> {
           onTap: () {
             if (hasLogin) {
               //issue 未登陆状态 返回登陆页面
-              Application.router.navigateTo(context, '${Routes.issuesMessage}');
+              Application.router.navigateTo(
+                context,
+                '${Routes.issuesMessage}',
+                transition: TransitionType.nativeModal,
+              );
             } else {
               //No description provided.
-              Application.router.navigateTo(context, '${Routes.loginPage}');
+              Application.router.navigateTo(
+                context,
+                '${Routes.loginPage}',
+                transition: TransitionType.nativeModal,
+              );
             }
           },
         ),

--- a/lib/views/first_page/main_page.dart
+++ b/lib/views/first_page/main_page.dart
@@ -1,3 +1,4 @@
+import 'package:fluro/fluro.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_go/views/first_page/drawer_page.dart';
@@ -84,16 +85,22 @@ class TabLayout extends StatelessWidget {
         onTap: (index) {
           if (index == 1) {
             DefaultTabController.of(context).animateTo(0);
-            Application.router.navigateTo(context,
-                '${Routes.webViewPage}?title=${Uri.encodeComponent('Flutter Go 官方网站')}&url=${Uri.encodeComponent('https://flutter-go.pub')}');
+            Application.router.navigateTo(
+              context,
+              '${Routes.webViewPage}?title=${Uri.encodeComponent('Flutter Go 官方网站')}&url=${Uri.encodeComponent('https://flutter-go.pub')}',
+              transition: TransitionType.nativeModal,
+            );
           } else if (index == 2) {
 //          new Future.delayed(const Duration(seconds: 1),(){
 //            showAlertDialog(Application.globalContext);
 //          });
 
             DefaultTabController.of(context).animateTo(0);
-            Application.router.navigateTo(context,
-                '${Routes.webViewPage}?title=${Uri.encodeComponent('Flutter Go web版(H5)')}&url=${Uri.encodeComponent('https://flutter-go.pub/flutter_go_web')}');
+            Application.router.navigateTo(
+              context,
+              '${Routes.webViewPage}?title=${Uri.encodeComponent('Flutter Go web版(H5)')}&url=${Uri.encodeComponent('https://flutter-go.pub/flutter_go_web')}',
+              transition: TransitionType.nativeModal,
+            );
           }
         });
     return _tabBar;

--- a/lib/views/first_page/search_page.dart
+++ b/lib/views/first_page/search_page.dart
@@ -1,3 +1,4 @@
+import 'package:fluro/fluro.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter/cupertino.dart';
@@ -27,8 +28,11 @@ final _industryPage = Industry.IndustryPage(itemTitle: (state) {
           print(state.res[index].source);
           final itemTitle = state.res[index].title;
           final itemUrl = state.res[index].source;
-          Application.router.navigateTo(context,
-              '${Routes.webViewPage}?title=${Uri.encodeComponent(itemTitle)}&url=${Uri.encodeComponent(itemUrl)}');
+          Application.router.navigateTo(
+            context,
+            '${Routes.webViewPage}?title=${Uri.encodeComponent(itemTitle)}&url=${Uri.encodeComponent(itemUrl)}',
+            transition: TransitionType.nativeModal,
+          );
         },
       );
     },

--- a/lib/views/fourth_page/pages.dart
+++ b/lib/views/fourth_page/pages.dart
@@ -1,3 +1,4 @@
+import 'package:fluro/fluro.dart';
 import 'package:flutter/material.dart';
 
 import '../../routers/application.dart';
@@ -51,8 +52,11 @@ class Page extends StatelessWidget {
               ..putBool(SharedPreferencesKeys.showWelcome, false);
             _goHomePage(context);
           } else if (type == 'goGithub') {
-            Application.router.navigateTo(context,
-                '${Routes.webViewPage}?title=${Uri.encodeComponent(txt)} Doc&&url=${Uri.encodeComponent("https://github.com/alibaba/flutter-go")}');
+            Application.router.navigateTo(
+              context,
+              '${Routes.webViewPage}?title=${Uri.encodeComponent(txt)} Doc&&url=${Uri.encodeComponent("https://github.com/alibaba/flutter-go")}',
+              transition: TransitionType.nativeModal,
+            );
           }
         },
         elevation: 10.0,
@@ -93,8 +97,12 @@ class Page extends StatelessWidget {
           Positioned(
               right: -5.0,
               top: paddingTop + 2.0,
-              child: creatButton(context, 'GitHub', Icons.arrow_forward, 'goGithub')
-          ),
+              child: creatButton(
+                context,
+                'GitHub',
+                Icons.arrow_forward,
+                'goGithub',
+              )),
         ]);
   }
 

--- a/lib/views/home.dart
+++ b/lib/views/home.dart
@@ -107,7 +107,7 @@ class _MyHomePageState extends State<AppPage>
         .add(SearchHistory(name: targetName, targetRouter: targetRouter));
     print("searchHistoryList1 ${searchHistoryList.toString()}");
     Application.router.navigateTo(context, targetRouter.toLowerCase(),
-        transition: TransitionType.inFromRight);
+        transition: TransitionType.native);
   }
 
   Widget buildSearchInput(BuildContext context) {

--- a/lib/views/login_page/login_page.dart
+++ b/lib/views/login_page/login_page.dart
@@ -1,3 +1,4 @@
+import 'package:fluro/fluro.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:event_bus/event_bus.dart';
@@ -376,8 +377,11 @@ class _LoginPageState extends State<LoginPage> {
                                   decoration: TextDecoration.underline),
                             ),
                             onPressed: () {
-                              Application.router.navigateTo(context,
-                                  '${Routes.webViewPage}?title=Github&url=${Uri.encodeComponent("https://github.com/login/oauth/authorize?client_id=cfe4795e76382ae8a5bd&scope=user,public_repo")}');
+                              Application.router.navigateTo(
+                                context,
+                                '${Routes.webViewPage}?title=Github&url=${Uri.encodeComponent("https://github.com/login/oauth/authorize?client_id=cfe4795e76382ae8a5bd&scope=user,public_repo")}',
+                                transition: TransitionType.nativeModal,
+                              );
                             },
                           ),
                           FlatButton(
@@ -389,8 +393,11 @@ class _LoginPageState extends State<LoginPage> {
                             ),
                             onPressed: () {
                               Application.router.navigateTo(
-                                  context, Routes.home,
-                                  clearStack: true);
+                                context,
+                                Routes.home,
+                                clearStack: true,
+                                transition: TransitionType.nativeModal,
+                              );
                             },
                           )
                         ],

--- a/lib/views/standard_demo_page/index.dart
+++ b/lib/views/standard_demo_page/index.dart
@@ -7,6 +7,7 @@
 // tartget:  xxx
 //
 
+import 'package:fluro/fluro.dart';
 import 'package:flutter/material.dart';
 import '../../components/widget_demo.dart';
 import 'dart:convert';
@@ -146,8 +147,11 @@ class _StandardView extends State<StandardView> {
 
     String remoteSouceCode =
         '$githubHost/lib/page_demo_package/${demoDetail['name']}_${demoDetail['author']}_${demoDetail['id']}/src/index.dart';
-    Application.router.navigateTo(context,
-        '${Routes.githubCodeView}?remotePath=${Uri.encodeComponent(remoteSouceCode)}');
+    Application.router.navigateTo(
+      context,
+      '${Routes.githubCodeView}?remotePath=${Uri.encodeComponent(remoteSouceCode)}',
+      transition: TransitionType.nativeModal,
+    );
   }
 
   Widget buildFootInfo() {


### PR DESCRIPTION
## 本PR做了什么？
* 统一跳转行为，并支持侧滑返回（iOS）

## 修改范围
* `TransitionType.inFromRight` 改为 `TransitionType.native`
  * 其内部会在 iOS 平台使用 `CupertinoPageRoute`，在 android 平台是用 `MaterialPageRoute`，同时 iOS 上支持 `侧滑返回`
* 显示指定 `TransitionType.nativeModal`
  * 使用 `navigateTo` 进行跳转，如果没有指定 `TransitionType`,  则会使用 `SlideTransition` 进行跳转（表现为 bottom -> top），指定 `TransitionType.nativeModal` 之后在跳转动画上是保持一致的，其他特性跟随平台而定。fullscreenDialog 解释如下：

```dart 
 /// Whether this page route is a full-screen dialog.
  ///
  /// In Material and Cupertino, being fullscreen has the effects of making
  /// the app bars have a close button instead of a back button. On
  /// iOS, dialogs transitions animate differently and are also not closeable
  /// with the back swipe gesture.
  final bool fullscreenDialog;
```

